### PR TITLE
Add newline to post install commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1018,7 +1018,7 @@ if [[ "$(which brew)" != "${HOMEBREW_PREFIX}/bin/brew" ]]
 then
   cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >> ${shell_profile}
+    echo '\neval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >> ${shell_profile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 fi


### PR DESCRIPTION
When I installed homebrew, the command to update `~/.zprofile` outputted onto the same line as the previous command written to that file:

![image](https://user-images.githubusercontent.com/1562283/191366221-4577a9f5-2ab4-468a-b450-efdfb7107cb3.png)
